### PR TITLE
Recent tweaks

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -200,4 +200,7 @@ set statusline+=\
 " 'jk' exits insert mode - courtesy of Andrew Halle
 inoremap jk <ESC>
 
+" And disable my old way of doing things to help me learn!
+inoremap <C-[> <nop>
+
 " END EVERYTHING ELSE

--- a/.vimrc
+++ b/.vimrc
@@ -197,4 +197,7 @@ set statusline+=%=
 set statusline+=\ %l:%c
 set statusline+=\ 
 
+" 'jk' exits insert mode - courtesy of Andrew Halle
+inoremap jk <ESC>
+
 " END EVERYTHING ELSE

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -45,10 +45,6 @@ selection:
   # "semantic words" in Alacritty.
   semantic_escape_chars: ",│`|:\"' ()[]{}<>\t"
 
-# Do either of these work?
-mouse:
-  url:
-    launcher: None
 hints:
   mouse:
     enabled: false

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,12 +1,15 @@
-# for rbenv!
-status --is-interactive; and source (rbenv init -|psub)
-
-# for keychain!
-eval (ssh-agent -c)
-
 set PATH $PATH $HOME/.cargo/bin
+
+eval (ssh-agent -c)
+set -Ux SSH_AUTH_SOCK $SSH_AUTH_SOCK
+set -Ux SSH_AGENT_PID $SSH_AGENT_PID
+ssh-add ~/.ssh/github_id_ed25519
+
+starship init fish | source
+
+# From sway docs for Fish shell
+set TTY1 (tty)
+[ "$TTY1" = "/dev/tty1" ] && exec sway
 
 set -gx NVIM "/usr/local/bin/nvim"
 set -gx EDITOR "nvim"
-set -g fish_user_paths "/usr/local/opt/gettext/bin" $fish_user_paths
-set -g fish_user_paths "/usr/local/opt/node@12/bin" $fish_user_paths

--- a/i3/config
+++ b/i3/config
@@ -187,5 +187,11 @@ exec --no-startup-id xset r rate 200 40
 # Configure monitors
 exec --no-startup-id xrandr --output DP-0 --primary --output eDP-1-1 --left-of DP-0
 
-# Disable capslock
-exec --no-startup-id setxkbmap -option caps:none
+# Map capslock to windows key
+exec --no-startup-id setxkbmap -option caps:super
+
+# Hotkey for screen lock
+bindsym $mod+Control+l exec i3lock -e -c 000000
+
+# Follow https://wiki.archlinux.org/title/HiDPI#X_Resources
+# to get external 4k monitor correct even though nothing goes in here.

--- a/i3/config
+++ b/i3/config
@@ -178,6 +178,7 @@ bindsym $mod+r mode "resize"
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
+        output primary
         status_command i3status
 }
 
@@ -195,3 +196,36 @@ bindsym $mod+Control+l exec i3lock -e -c 000000
 
 # Follow https://wiki.archlinux.org/title/HiDPI#X_Resources
 # to get external 4k monitor correct even though nothing goes in here.
+
+# Start redshift for redness
+exec --no-startup-id redshift -O 2500
+
+# https://i3wm.org/docs/userguide.html#_scratchpad
+# Make the currently focused window a scratchpad
+bindsym $mod+Shift+minus move scratchpad
+
+# Show the first scratchpad window
+bindsym $mod+minus scratchpad show
+
+# Start bluetooth ... thing
+exec --no-startup-id blueman-applet
+
+# From Andrew - allow easily locking/shutting down, etc.
+# From https://gitlab.manjaro.org/packages/community/i3/i3exit.
+# Set shut down, restart and locking features
+# bindsym $mod+Delete mode "$mode_system"
+# bindsym $mod+Pause mode "$mode_system"
+# set $mode_system (l)ock, (e)xit, switch_(u)ser, (s)uspend, (h)ibernate, (r)eboot, (Shift+s)hutdown
+# mode "$mode_system" {
+#     bindsym l exec --no-startup-id i3exit lock, mode "default"
+#     bindsym s exec --no-startup-id i3exit suspend, mode "default"
+#     bindsym u exec --no-startup-id i3exit switch_user, mode "default"
+#     bindsym e exec --no-startup-id i3exit logout, mode "default"
+#     bindsym h exec --no-startup-id i3exit hibernate, mode "default"
+#     bindsym r exec --no-startup-id i3exit reboot, mode "default"
+#     bindsym Shift+s exec --no-startup-id i3exit shutdown, mode "default"
+# 
+#     # exit system mode: "Enter" or "Escape"
+#     bindsym Return mode "default"
+#     bindsym Escape mode "default"
+# }

--- a/init.vim
+++ b/init.vim
@@ -1,0 +1,3 @@
+set runtimepath^=~/.vim runtimepath+=~/.vim/after
+let &packpath = &runtimepath
+source ~/.vimrc


### PR DESCRIPTION
- `jk` to exit insert in vim
- remove deprecated `url` alacritty config because `hints` is correct
- tweak `fish` config but it's definitely still wrong and needs love
- add `init.vim` - it's supplied by `nvim` but it's easier to copy from here for now :shrug: (though I guess I have to maintain it? Maybe I shouldn't do this...)