### PR TITLE
Fix SSH agent in fish and other niceties

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -48,8 +48,3 @@ selection:
 hints:
   mouse:
     enabled: false
-
-shell:
-  program: /usr/bin/fish
-  args:
-    - --login

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,17 +1,23 @@
 set -gx NVIM "/usr/local/bin/nvim"
 set -gx EDITOR "nvim"
 
-# Sourcing ~/.cargo/env doesn't work for Fish?
-# See https://github.com/rust-lang/rustup/issues/478#issuecomment-331625472
-set PATH $HOME/.cargo/bin $PATH
-
 # for https://starship.rs/guide/#%F0%9F%9A%80-installation
 starship init fish | source
 
 # https://gist.github.com/josh-padnick/c90183be3d0e1feb89afd7573505cab3?permalink_comment_id=3806363#gistcomment-3806363
-if test -z (pgrep ssh-agent | string collect)
-    eval (ssh-agent -c)
-    set -Ux SSH_AUTH_SOCK $SSH_AUTH_SOCK
-    set -Ux SSH_AGENT_PID $SSH_AGENT_PID
-    # ssh-add ~/.ssh/path_to_private_key
+# Starts SSH agent if it isn't started
+if status is-login
+  if test -z (pgrep ssh-agent | string collect)
+      eval (ssh-agent -c)
+      set -Ux SSH_AUTH_SOCK $SSH_AUTH_SOCK
+      set -Ux SSH_AGENT_PID $SSH_AGENT_PID
+  end
+
+  # ssh-add ~/.ssh/path_to_private_key
+end
+
+# https://github.com/fish-shell/fish-shell/issues/4434
+if status is-interactive
+and not set -q TMUX
+    exec tmux
 end


### PR DESCRIPTION
**This Commit**

- Removes the `shell` config in `alacritty.yml` because it uses the login shell by default which should already be `fish`
- Removes the addition of `~/.cargo/bin` to `$PATH` in `config.fish` because I was seeing duplicates
- Nests the `ssh-agent` starting in a `is-login` check since I just need one of those per login, not per shell
- Adds my SSH identity once per login shell for the same reason
- Starts tmux automatically in interactive shells.