### PR TITLE
Use leader for rename keybinding

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -131,7 +131,7 @@ nnoremap <silent> gr    <cmd>lua vim.lsp.buf.references()<CR>
 nnoremap <silent> g0    <cmd>lua vim.lsp.buf.document_symbol()<CR>
 nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
 nnoremap <silent> gd    <cmd>lua vim.lsp.buf.definition()<CR>
-nnoremap <silent> gn    <cmd>lua vim.lsp.buf.rename()<CR>
+nnoremap <leader>rn    <cmd>lua vim.lsp.buf.rename()<CR>
 
 nnoremap <silent> ga    <cmd>lua vim.lsp.buf.code_action()<CR>
 


### PR DESCRIPTION
I tried this before but I'd done `<leader> rn` instead of `<leader>rn` and everything went to hell. Doing this makes things consistent with my old `coc.nvim` setup and unlocks `gn` for applying vim commands to search results.

Kudos to Andrew Halle!