### PR TITLE
Switch escaping insert from `jk` to `kj`

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -232,8 +232,8 @@ set statusline+=%=
 set statusline+=\ %l:%c
 set statusline+=\ 
 
-" Map 'jk' to Esc so that exits insert mode courtesy of AHalle
-inoremap jk <ESC>
+" Map 'kj' to Esc so that exits insert mode courtesy of AHalle + ALehmer
+inoremap kj <ESC>
 
 " And disable my old way of doing things to help me learn!
 inoremap <C-[> <nop>


### PR DESCRIPTION
## Why?

This is nice because sometimes I use `jk` for "just kidding" and accidentally exit insert mode. `kj` seems less common. It's also a roll towards the index finger which Andrew Lehmer mentioned is more ergonomic. We'll see how this goes!